### PR TITLE
update ndarray to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusticsom"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Avinash Shenoy <avi123shenoy@hotmail.com>", "Aditi Srinivas <aditisrinivas97@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/avinashshenoy97/RusticSOM"
@@ -13,6 +13,6 @@ edition = "2018"
 
 [dependencies]
 rand = "0.4"
-ndarray = { version = "0.11", features = ["serde-1"] }
+ndarray = { version = "0.13", features = ["serde-1"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ impl SOM {
                     self.data.map[[i, j, k]] += (elem[[k]] - self.data.map[[i, j, k]]) * g[[i, j]];
                 }
 
-                _temp_norm = norm(self.data.map.subview(Axis(0), i).subview(Axis(0), j));
+                _temp_norm = norm(self.data.map.index_axis(Axis(0), i).index_axis(Axis(0), j));
                 for k in 0..self.data.z {
                     self.data.map[[i, j, k]] /= _temp_norm;
                 }
@@ -204,7 +204,7 @@ impl SOM {
 
         let temp = self.winner(elem);
 
-        (temp, euclid_dist(self.data.map.subview(Axis(0), temp.0).subview(Axis(0), temp.1), tempelem.view()))
+        (temp, euclid_dist(self.data.map.index_axis(Axis(0), temp.0).index_axis(Axis(0), temp.1), tempelem.view()))
     }
 
     // Returns size of SOM.
@@ -222,7 +222,7 @@ impl SOM {
                 temp_dist = 0.0;
                 for k in 0..self.data.x{
                     for l in 0..self.data.y{
-                        temp_dist += euclid_dist(self.data.map.subview(Axis(0), i).subview(Axis(0), j), self.data.map.subview(Axis(0), k).subview(Axis(0), l));
+                        temp_dist += euclid_dist(self.data.map.index_axis(Axis(0), i).index_axis(Axis(0), j), self.data.map.index_axis(Axis(0), k).index_axis(Axis(0), l));
                     }
                 }
                 if temp_dist > max_dist {

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -2,7 +2,7 @@ extern crate rusticsom;
 extern crate ndarray;
 
 use rusticsom::*;
-use ndarray::{Array1, Array2};
+use ndarray::{Array2};
 
 #[test]
 fn t_full_test() {


### PR DESCRIPTION
This updates the ndarray dependency to 0.13 for compatibility with minor changes to the public types. I also bumped the version number to 1.1.1 and fixed some unused warnings. 

Side-note: I noticed the 1.1.0 version did not seem to be published to crates, but using the repository url in the cargo file is an easy workaround. 