### PR TITLE
Simplify code where possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_script:
 script:
   - cargo test --verbose
   - cargo fmt -- --check
-  - cargo clippy -- -Dclippy::all
+  - cargo clippy -- -D clippy::all -D clippy::suboptimal-flops

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,9 @@ impl SOM {
     }
 
     // To find and return the position of the winner neuron for a given input sample.
+    //
+    // TODO: (breaking-change) switch `elem` to `ArrayView1`. See todo
+    //       for `Self::winner_dist()`.
     pub fn winner(&mut self, elem: Array1<f64>) -> (usize, usize) {
         let mut temp: Array1<f64> = Array1::<f64>::zeros(self.data.z);
         let mut min: f64 = std::f64::MAX;
@@ -190,6 +193,11 @@ impl SOM {
     }
 
     // Similar to winner(), but also returns distance of input sample from winner neuron.
+    //
+    // TODO: (breaking-change) make `elem` an `ArrayView1` to remove
+    //       at least one heap allocation. Requires same change to
+    //       `Self::winner()`.
+    //
     pub fn winner_dist(&mut self, elem: Array1<f64>) -> ((usize, usize), f64) {
         // TODO: use more descriptive names than temp[..]
         let tempelem = elem.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,19 +323,17 @@ fn gaussian(dims: (usize, usize), pos: (usize, usize), sigma: f32) -> Array2<f64
     Array2::from_shape_fn(dims, shape_fn)
 }
 
-// Returns the euclidian distance between 2 vectors
+/// Returns the [Euclidean distance] between `a` and `b`.
+///
+/// [Euclidean distance]: https://en.wikipedia.org/wiki/Euclidean_distance
 fn euclid_dist(a: ArrayView1<f64>, b: ArrayView1<f64>) -> f64 {
-    if a.len() != b.len() {
-        panic!("Both arrays must be of same length to find Euclidian distance!");
-    }
+    debug_assert_eq!(a.len(), b.len());
 
-    let mut dist: f64 = 0.0;
-
-    for i in 0..a.len() {
-        dist += (a[i] - b[i]).powf(2.0);
-    }
-
-    dist.powf(0.5)
+    a.iter()
+        .zip(b.iter())
+        .map(|(a, b)| (a - b).powi(2))
+        .sum::<f64>()
+        .sqrt()
 }
 
 // Unit-testing module - only compiled when "cargo test" is run!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,20 +256,14 @@ impl SOM {
 
     // Unit testing functions for setting individual cell weights
     #[cfg(test)]
-    pub fn set_map_cell(&mut self, pos: (usize, usize, usize), val: f64) {
-        if let Some(elem) = self.data.map.get_mut(pos) {
-            *(elem) = val;
-        }
+    pub fn set_map_cell(&mut self, (i, j, k): (usize, usize, usize), val: f64) {
+        self.data.map[[i, j, k]] = val;
     }
 
     // Unit testing functions for getting individual cell weights
     #[cfg(test)]
-    pub fn get_map_cell(&self, pos: (usize, usize, usize)) -> f64 {
-        if let Some(elem) = self.data.map.get(pos) {
-            *(elem)
-        } else {
-            panic!("Invalid index!");
-        }
+    pub fn get_map_cell(&self, (i, j, k): (usize, usize, usize)) -> f64 {
+        self.data.map[[i, j, k]]
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,37 +308,19 @@ fn default_decay_fn(val: f32, curr_iter: u32, max_iter: u32) -> f64 {
     (val as f64) / ((1 + (curr_iter / max_iter)) as f64)
 }
 
-// Default neighbourhood function: Gaussian function; returns a Gaussian centered in pos
-fn gaussian(size: (usize, usize), pos: (usize, usize), sigma: f32) -> Array2<f64> {
-    let mut ret = Array2::<f64>::zeros((size.0, size.1));
-    let div = 2.0 * PI * sigma as f64 * sigma as f64;
+/// Default neighborhood function.
+///
+/// Returns a two-dimensional Gaussian distribution centered at `pos`.
+fn gaussian(dims: (usize, usize), pos: (usize, usize), sigma: f32) -> Array2<f64> {
+    let div = 2.0 * PI * (sigma as f64).powi(2);
 
-    let mut x: Vec<f64> = Vec::new();
-    let mut y: Vec<f64> = Vec::new();
+    let shape_fn = |(i, j)| {
+        let x = (-((i as f64 - (pos.0 as f64)).powi(2) / div)).exp();
+        let y = (-((j as f64 - (pos.1 as f64)).powi(2) / div)).exp();
+        x * y
+    };
 
-    for i in 0..size.0 {
-        x.push(i as f64);
-        if let Some(elem) = x.get_mut(i) {
-            *elem = -((*elem - (pos.0 as f64)).powf(2.0) / div);
-            *elem = (*elem).exp();
-        }
-    }
-
-    for i in 0..size.1 {
-        y.push(i as f64);
-        if let Some(elem) = y.get_mut(i) {
-            *elem = -((*elem - (pos.1 as f64)).powf(2.0) / div);
-            *elem = (*elem).exp();
-        }
-    }
-
-    for i in 0..size.0 {
-        for j in 0..size.1 {
-            ret[[i, j]] = x[i] * y[j];
-        }
-    }
-
-    ret
+    Array2::from_shape_fn(dims, shape_fn)
 }
 
 // Returns the euclidian distance between 2 vectors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,13 +294,7 @@ impl fmt::Display for SOM {
 
 // Returns the 2-norm of a vector represented as a 1D ArrayView
 fn norm(a: ArrayView1<f64>) -> f64 {
-    let mut ret: f64 = 0.0;
-
-    for i in a.iter() {
-        ret += i.powi(2);
-    }
-
-    ret.sqrt()
+    a.iter().map(|elem| elem.powi(2)).sum::<f64>().sqrt()
 }
 
 // The default decay function for LR and Sigma

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,10 +297,10 @@ fn norm(a: ArrayView1<f64>) -> f64 {
     let mut ret: f64 = 0.0;
 
     for i in a.iter() {
-        ret += i.powf(2.0);
+        ret += i.powi(2);
     }
 
-    ret.powf(0.5)
+    ret.sqrt()
 }
 
 // The default decay function for LR and Sigma

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,6 +324,7 @@ fn euclid_dist(a: ArrayView1<f64>, b: ArrayView1<f64>) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ndarray::array;
 
     #[test]
     fn test_winner() {
@@ -343,8 +344,8 @@ mod tests {
 
     #[test]
     fn test_euclid() {
-        let a = Array1::from(vec![1.0, 2.0, 3.0, 4.0]);
-        let b = Array1::from(vec![4.0, 5.0, 6.0, 7.0]);
+        let a = array![1.0, 2.0, 3.0, 4.0];
+        let b = array![4.0, 5.0, 6.0, 7.0];
 
         assert_eq!(euclid_dist(a.view(), b.view()), 6.0);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,14 +191,8 @@ impl SOM {
 
     // Similar to winner(), but also returns distance of input sample from winner neuron.
     pub fn winner_dist(&mut self, elem: Array1<f64>) -> ((usize, usize), f64) {
-        let mut tempelem = Array1::<f64>::zeros(elem.len());
-
-        for i in 0..elem.len() {
-            if let Some(temp) = tempelem.get_mut(i) {
-                *(temp) = elem[i];
-            }
-        }
-
+        // TODO: use more descriptive names than temp[..]
+        let tempelem = elem.clone();
         let temp = self.winner(elem);
 
         (

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,7 @@
 extern crate ndarray;
 extern crate rusticsom;
 
-use ndarray::{Array1, Array2};
+use ndarray::{array, Array1, Array2};
 use rusticsom::*;
 
 #[test]
@@ -45,7 +45,7 @@ fn t_full_test() {
     // Run with `cargo test -- --nocapture` to get output!
     // Plotted with Matplotlib
     let mut map = SOM::create(10, 10, 4, false, None, None, None, None);
-    let data = Array2::from(vec![
+    let data = array![
         [5.1, 3.5, 1.4, 0.2],
         [4.9, 3.0, 1.4, 0.2],
         [4.7, 3.2, 1.3, 0.2],
@@ -196,7 +196,7 @@ fn t_full_test() {
         [6.5, 3.0, 5.2, 2.0],
         [6.2, 3.4, 5.4, 2.3],
         [5.9, 3.0, 5.1, 1.8],
-    ]);
+    ];
 
     let data2 = data.to_owned();
     map.train_random(data, 1000);

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -1,7 +1,7 @@
 extern crate ndarray;
 extern crate rusticsom;
 
-use ndarray::Array2;
+use ndarray::array;
 use rusticsom::*;
 
 #[test]
@@ -9,7 +9,7 @@ fn t_full_test() {
     // Run with `cargo test -- --nocapture` to get output!
     // Plotted with Matplotlib
     let mut map = SOM::create(10, 10, 4, false, None, None, None, None);
-    let data = Array2::from(vec![
+    let data = array![
         [5.1, 3.5, 1.4, 0.2],
         [4.9, 3.0, 1.4, 0.2],
         [4.7, 3.2, 1.3, 0.2],
@@ -160,7 +160,7 @@ fn t_full_test() {
         [6.5, 3.0, 5.2, 2.0],
         [6.2, 3.4, 5.4, 2.3],
         [5.9, 3.0, 5.1, 1.8],
-    ]);
+    ];
 
     let data2 = data.to_owned();
     map.train_random(data, 1000);


### PR DESCRIPTION
This PR is a non-comprehensive<sup>1</sup> effort to:

- reduce temporary heap allocations
- delete unnecessary code
- improve readability

1: I have [another branch] with more aggressive, but API breaking, optimizations that remove a lot of heap allocations. I can open a follow-up PR for that along with a major version bump.

[another branch]: https://github.com/JayKickliter/RusticSOM/tree/jsk/breaking/reduce-heap-allocations