### PR TITLE
[docs] Reformat docstrings to be auto-generated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusticsom"
-version = "1.1.1"
+version = "2.0.0"
 authors = ["Avinash Shenoy <avi123shenoy@hotmail.com>", "Aditi Srinivas <aditisrinivas97@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/avinashshenoy97/RusticSOM"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RusticSOM
+
 Rust library for Self Organising Maps (SOM).
 
 ![Status](https://img.shields.io/badge/status-active-brightgreen.svg?style=flat)
@@ -9,11 +9,13 @@ Rust library for Self Organising Maps (SOM).
 
 ## Using this Crate
 
-Add `rusticsom` as a dependency in `Cargo.toml`
+Add `rusticsom` as a dependency in `Cargo.toml`, as well as version 0.13 of
+`ndarray`:
 
 ```toml
 [dependencies]
 rusticsom = "1.1.0"
+ndarray = { version = "0.13", features = ["serde-1"] }
 ```
 
 Include the crate 
@@ -166,3 +168,27 @@ Using a 10 x 10 SOM, trained for 1000 iterations :
 |Circle|setosa|
 |Square|versicolor|
 |Diamond|virginica|
+
+## Troubleshooting
+
+If you get an error like:
+
+```
+error[E0308]: mismatched types
+   --> src/main.rs:163:22
+    |
+163 |     map.train_random(data, 1000);
+    |                      ^^^^ expected struct `ndarray::ArrayBase`, found struct `ArrayBase`
+    |
+    = note: expected struct `ndarray::ArrayBase<ndarray::data_repr::OwnedRepr<f64>, ndarray::dimension::dim::Dim<[usize; 2]>>`
+               found struct `ArrayBase<OwnedRepr<{float}>, Dim<[usize; 2]>>`
+    = note: perhaps two different versions of crate `ndarray` are being used?
+```
+Then make sure you're NOT using the latest version of `ndarray`, but rather
+version 0.13 like:
+
+```
+[dependencies]
+rusticsom = "1.1.0"
+ndarray = { version = "0.13", features = ["serde-1"] }
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+# RusticSOM
 Rust library for Self Organising Maps (SOM).
 
 ![Status](https://img.shields.io/badge/status-active-brightgreen.svg?style=flat)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,12 +117,14 @@ impl SOM {
 
         for i in 0..self.data.x {
             for j in 0..self.data.y {
-                // delta = &self.data.map.slice(s![i, j, ..]) - &elem.view();
-                // TODO this assertion just checks that the above broadcasting slice doesn't change
-                // anything. the below assertion can be removed if nothing breaks for a while
                 for k in 0..self.data.z {
-                    // assert_eq!(delta[k], self.data.map[[i, j, k]] - elem[[k]]);
-                    delta[k] = self.data.map[[i, j, k]] - elem[[k]];
+                    // If a sample value is nan, ignore it and assume that the sample is identical
+                    // in this feature (so set the difference to zero)
+                    delta[k] = if elem[[k]].is_nan() {
+                        0.0
+                    } else {
+                        self.data.map[[i, j, k]] - elem[[k]]
+                    };
                 }
 
                 let magnitude = norm(delta.view());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,12 @@ use std::fmt;
 /// Contains the data about the Self Organising Map
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SomData {
-    /// Length of SOM
+    /// Length of the SOM
     x: usize,
-    /// Breadth of SOM
+    /// Breadth of the SOM
     y: usize,
-    /// size of inputs
+    /// The number of elements in each neuron. Must equal the number of features in each sample of
+    /// the input data
     z: usize,
     /// initial learning rate
     learning_rate: f32,
@@ -100,35 +101,39 @@ impl SOM {
         }
     }
 
-    /// Find and return the position of the winner neuron for a given input sample.
+    /// Find and return the position of the winner neuron for a given input sample. This is called
+    /// the Best Matching Unit (BMU) in the literature
     ///
     /// TODO: (breaking-change) switch `elem` to `ArrayView1`. See todo
     ///       for `Self::winner_dist()`.
     pub fn winner(&mut self, elem: Array1<f64>) -> (usize, usize) {
-        let mut temp: Array1<f64> = Array1::<f64>::zeros(self.data.z);
-        let mut min: f64 = std::f64::MAX;
-        let mut ret: (usize, usize) = (0, 0);
+        let mut delta: Array1<f64> = Array1::<f64>::zeros(self.data.z);
+        let mut min_magnitude = f64::MAX;
+        let mut winning_neuron = (0, 0);
 
         for i in 0..self.data.x {
             for j in 0..self.data.y {
+                // delta = &self.data.map.slice(s![i, j, ..]) - &elem.view();
+                // TODO this assertion just checks that the above broadcasting slice doesn't change
+                // anything. the below assertion can be removed if nothing breaks for a while
                 for k in 0..self.data.z {
-                    temp[k] = self.data.map[[i, j, k]] - elem[[k]];
+                    // assert_eq!(delta[k], self.data.map[[i, j, k]] - elem[[k]]);
+                    delta[k] = self.data.map[[i, j, k]] - elem[[k]];
                 }
 
-                let norm = norm(temp.view());
+                let magnitude = norm(delta.view());
 
-                if norm < min {
-                    min = norm;
-                    ret = (i, j);
+                if magnitude < min_magnitude {
+                    min_magnitude = magnitude;
+                    winning_neuron = (i, j);
                 }
             }
         }
-
-        if let Some(elem) = self.data.activation_map.get_mut(ret) {
-            *(elem) += 1;
+        // Increment the winning neuron's activation
+        if let Some(elem) = self.data.activation_map.get_mut(winning_neuron) {
+            *elem += 1;
         }
-
-        ret
+        winning_neuron
     }
 
     /// Use the provided JSON string to create a SOM. The JSON string should have come from
@@ -152,24 +157,33 @@ impl SOM {
         serde_json::to_string_pretty(&self.data)
     }
 
-    /// Update the weights of the SOM
+    /// Update the weights of the SOM given a sample `elem`, the winning neuron for that sample
+    /// `winner`, and the iteration number `iteration_index`.
     fn update(&mut self, elem: Array1<f64>, winner: (usize, usize), iteration_index: u32) {
+        // Decay the learning rate based on the decay function
         let new_lr = (self.decay_fn)(
             self.data.learning_rate,
             iteration_index,
             self.data.regulate_lrate,
         );
-        let new_sig = (self.decay_fn)(self.data.sigma, iteration_index, self.data.regulate_lrate);
+        // Decay the value of sigma based on the decay function
+        let new_sigma = (self.decay_fn)(self.data.sigma, iteration_index, self.data.regulate_lrate);
 
         let g =
-            (self.neighbourhood_fn)((self.data.x, self.data.y), winner, new_sig as f32) * new_lr;
+            (self.neighbourhood_fn)((self.data.x, self.data.y), winner, new_sigma as f32) * new_lr;
 
+        // Iterate over every neuron
         for i in 0..self.data.x {
             for j in 0..self.data.y {
+                // Iterate over every value in the current neuron
                 for k in 0..self.data.z {
-                    self.data.map[[i, j, k]] += (elem[[k]] - self.data.map[[i, j, k]]) * g[[i, j]];
+                    // Get the difference between the the new neuron value and the old neuron value
+                    let delta = elem[[k]] - self.data.map[[i, j, k]];
+                    // Update the neuron to be the change multiplied by the result of the
+                    // neighbourhood function
+                    self.data.map[[i, j, k]] += g[[i, j]] * delta;
                 }
-
+                // Normalise all of the values of this neuron
                 let norm = norm(self.data.map.index_axis(Axis(0), i).index_axis(Axis(0), j));
                 for k in 0..self.data.z {
                     self.data.map[[i, j, k]] /= norm;
@@ -182,19 +196,23 @@ impl SOM {
     /// iterations.
     pub fn train_random(&mut self, data: Array2<f64>, iterations: u32) {
         let mut random_value: i32;
-        let mut temp1: Array1<f64>;
-        let mut temp2: Array1<f64>;
+        let mut sample: Array1<f64>;
+        let mut sample_copy: Array1<f64>;
         self.update_regulate_lrate(iterations);
         for iteration in 0..iterations {
-            temp1 = Array1::<f64>::zeros(ndarray::ArrayBase::dim(&data).1);
-            temp2 = Array1::<f64>::zeros(ndarray::ArrayBase::dim(&data).1);
+            sample = Array1::<f64>::zeros(ndarray::ArrayBase::dim(&data).1);
+            sample_copy = Array1::<f64>::zeros(ndarray::ArrayBase::dim(&data).1);
+            // Randomly choose an index from `data`
             random_value = rand::thread_rng().gen_range(0, ndarray::ArrayBase::dim(&data).0 as i32);
+            // Iterate over all values in the randomly chosen sample and add them to an array
             for i in 0..ndarray::ArrayBase::dim(&data).1 {
-                temp1[i] = data[[random_value as usize, i]];
-                temp2[i] = data[[random_value as usize, i]];
+                sample[i] = data[[random_value as usize, i]];
+                sample_copy[i] = data[[random_value as usize, i]];
             }
-            let win = self.winner(temp1);
-            self.update(temp2, win, iteration);
+            // Find the winner neuron for the randomly chosen sample
+            let winner = self.winner(sample);
+            // Update the map based on the randomly chosen sample's results
+            self.update(sample_copy, winner, iteration);
             // Iterate over the callbacks and execute them so the user can hook into training
             for cb in self.callbacks.clone() {
                 (cb)(self, iteration);
@@ -235,7 +253,8 @@ impl SOM {
     }
 
     /// Return both the coordinates of the winning neuron for a given sample, as well as the
-    /// distance from that sample to the neuron. Similar to `SOM::winner()`.
+    /// distance from that sample to the neuron. Similar to `SOM::winner()`. The winner is called
+    /// the Best Matching Unit (BMU) in the literature
     ///
     /// TODO: (breaking-change) make `elem` an `ArrayView1` to remove
     ///       at least one heap allocation. Requires same change to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,8 +200,12 @@ impl SOM {
                 }
                 // Normalise all of the values of this neuron
                 let norm = norm(self.data.map.index_axis(Axis(0), i).index_axis(Axis(0), j));
-                for k in 0..self.data.z {
-                    self.data.map[[i, j, k]] /= norm;
+                // Sometimes norm can be zero due to the neuron having extremely tiny values that
+                // are squared and become zero. Adding norm > 0 avoids NaNs in the neurons
+                if norm > 0.0 {
+                    for k in 0..self.data.z {
+                        self.data.map[[i, j, k]] /= norm;
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ impl SOM {
         neighbourhood_fn: Option<NeighbourhoodFn>,
         callbacks: Option<Vec<CallbackFn>>,
     ) -> serde_json::Result<SOM> {
-        let data: SomData = serde_json::from_str(&serialized)?;
+        let data: SomData = serde_json::from_str(serialized)?;
 
         Ok(SOM {
             data,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ impl SOM {
         // Decay the value of sigma based on the decay function
         let new_sigma = (self.decay_fn)(self.data.sigma, iteration_index, self.data.regulate_lrate);
 
-        let g =
+        let neighbour_vals =
             (self.neighbourhood_fn)((self.data.x, self.data.y), winner, new_sigma as f32) * new_lr;
 
         // Iterate over every neuron
@@ -187,7 +187,7 @@ impl SOM {
                     let delta = elem[[k]] - self.data.map[[i, j, k]];
                     // Update the neuron to be the change multiplied by the result of the
                     // neighbourhood function
-                    self.data.map[[i, j, k]] += g[[i, j]] * delta;
+                    self.data.map[[i, j, k]] += neighbour_vals[[i, j]] * delta;
                 }
                 // Normalise all of the values of this neuron
                 let norm = norm(self.data.map.index_axis(Axis(0), i).index_axis(Axis(0), j));

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -175,7 +175,7 @@ fn t_full_test() {
 
     let json = map.to_json().unwrap();
 
-    let mut map_imported = SOM::from_json(&json, None, None).unwrap();
+    let mut map_imported = SOM::from_json(&json, None, None, None).unwrap();
 
     for x in data2.genrows() {
         let y1 = x.to_owned();


### PR DESCRIPTION
Hey!

Dunno if you're accepting PRs, but this is a documentation-only change that basically just uses `///` instead of `//` for docstrings, so that the auto-generated documentation on [docs.rs](https://docs.rs/rusticsom/1.1.1/rusticsom/) will actually display all the existing documentation.